### PR TITLE
Basic Static Google Map Added

### DIFF
--- a/C4SGWeb/src/app/about/about.component.html
+++ b/C4SGWeb/src/app/about/about.component.html
@@ -2,9 +2,9 @@
   Our Office Location
 </b>
 
-<p>
-  todo add static google map here
-</p>
+<br>
+
+<img width="640" src="https://maps.googleapis.com/maps/api/staticmap?autoscale=1&size=640x420&maptype=roadmap&key=AIzaSyD9n6KasSkB0QvESMyH0tL8UhEtxjvEVrs&format=png&visual_refresh=true&markers=size:mid%7Ccolor:0xff0000%7Clabel:%7CUnited+States" alt="Code for Social Good Volunteer Locations">
 
 <br>
 


### PR DESCRIPTION
This is the basic static google map for the about us page. Ideally, we would retrieve the markers from the back-end. I believe a separate task should be created to integrate the map with the back-end.